### PR TITLE
fix: 🐛 Server gets stuck at "Starting" state

### DIFF
--- a/Storage/egg-s-c-p--s-l-proxy.json
+++ b/Storage/egg-s-c-p--s-l-proxy.json
@@ -17,7 +17,7 @@
     "startup": ".\/XProxy",
     "config": {
         "files": "{}",
-        "startup": "{\n    \"done\": \"Listening on server\"\n}",
+        "startup": "{\n    \"done\": \"Listening on\"\n}",
         "logs": "{}",
         "stop": "^C"
     },


### PR DESCRIPTION
The startup message to listen for was incorrectly set, updated it